### PR TITLE
Remove assert

### DIFF
--- a/include/deal.II/fe/fe_hermite.h
+++ b/include/deal.II/fe/fe_hermite.h
@@ -119,6 +119,9 @@ public:
   virtual std::unique_ptr<FiniteElement<dim, spacedim>>
   clone() const override;
 
+  virtual UpdateFlags
+  requires_update_flags(const UpdateFlags update_flags) const override;
+
   /**
    * @copydoc dealii::FiniteElement::hp_vertex_dof_identities() 
    */

--- a/include/deal.II/fe/fe_update_flags.h
+++ b/include/deal.II/fe/fe_update_flags.h
@@ -205,6 +205,10 @@ enum UpdateFlags
    * pushed forward to the real cell coordinates.
    */
   update_jacobian_pushed_forward_3rd_derivatives = 0x1000000,
+  /**
+   * Update rescaling for Hermite elements.
+   */
+  update_rescale = 0x2000000,
   //! Values needed for Piola transform
   /**
    * Combination of the flags needed for Piola transform of Hdiv elements.
@@ -226,7 +230,9 @@ enum UpdateFlags
   update_covariant_transformation | update_contravariant_transformation |
   update_transformation_values | update_transformation_gradients |
   // Volume data
-  update_volume_elements
+  update_volume_elements |
+  // Hermite
+  update_rescale
 };
 
 

--- a/source/fe/fe_hermite.cc
+++ b/source/fe/fe_hermite.cc
@@ -572,7 +572,7 @@ FE_Hermite<dim, spacedim>::requires_update_flags(const UpdateFlags flags) const
 {
   UpdateFlags out = FE_Poly<dim, spacedim>::requires_update_flags(flags);
   if (flags&(update_values|update_gradients|update_hessians|update_3rd_derivatives))
-    out |= update_JxW_values; // TODO: trigger that InternalData is created
+    out |= update_rescale; // since we need to rescale values, gradients, ...
   return out;
 }
 

--- a/source/fe/fe_hermite.cc
+++ b/source/fe/fe_hermite.cc
@@ -566,6 +566,17 @@ FE_Hermite<dim, spacedim>::clone() const
 }
 
 
+template <int dim, int spacedim>
+UpdateFlags
+FE_Hermite<dim, spacedim>::requires_update_flags(const UpdateFlags flags) const
+{
+  UpdateFlags out = FE_Poly<dim, spacedim>::requires_update_flags(flags);
+  if (flags&(update_values|update_gradients|update_hessians|update_3rd_derivatives))
+    out |= update_JxW_values; // TODO: trigger that InternalData is created
+  return out;
+}
+
+
 
 /**
  * A large part of the following function is copied from FE_Q_Base, the main 

--- a/source/fe/fe_hermite.cc
+++ b/source/fe/fe_hermite.cc
@@ -844,13 +844,6 @@ FE_Hermite<dim, spacedim>::fill_fe_values(
   const typename FE_Hermite<dim, spacedim>::InternalData &fe_data =
     static_cast<const typename FE_Hermite<dim, spacedim>::InternalData &>(
       fe_internal);
-
-  Assert(
-    ((dynamic_cast<const typename MappingHermite<dim, spacedim>::InternalData *>(
-       &mapping_internal) != nullptr) ||
-      (dynamic_cast<const typename MappingCartesian<dim>::InternalData *>(
-         &mapping_internal) != nullptr)), 
-    ExcInternalError());
     
 
   const UpdateFlags flags(fe_data.update_each);


### PR DESCRIPTION
I have remote the assert. Let me explain what is the issue. 

The issue happens on cells that are cut, i.e., they are both inside and outside. We request at https://github.com/dealii/dealii/blob/c002d65f449c5d680519512bd60295a5b90e8a52/examples/step-85/step-85.cc#L347-L351 only flags for the inside `FEValues` instance. The result of this is that no specialized mapping data is created but only `Mapping::InternalDataBase` (see https://github.com/dealii/dealii/blob/c002d65f449c5d680519512bd60295a5b90e8a52/source/fe/fe_values.cc#L4183-L4184). The result is that the cast to `MappingCartesian::InternalData` fails. As far as I see it we can remove the assert. Since no flag is active, all the computations below will not be computed. Am I right?